### PR TITLE
Add ability to mirror icons

### DIFF
--- a/docs-src/pages/UiIcon.vue
+++ b/docs-src/pages/UiIcon.vue
@@ -152,6 +152,15 @@
                                     <p>See the <b>Using SVG: <code>&lt;use&gt;</code></b> section above for details.</p>
                                 </td>
                             </tr>
+
+                            <tr>
+                                <td>mirror</td>
+                                <td>Boolean</td>
+                                <td><code>false</code></td>
+                                <td>
+                                    <p>Whether or not to mirror the icon. Useful for RTL support of certain icons.</p>
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/src/UiIcon.vue
+++ b/src/UiIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <span class="ui-icon" :class="[iconSet, icon]" :aria-label="ariaLabel">
+    <span class="ui-icon" :class="[iconSet, icon, { 'is-mirrored': mirror }]" :aria-label="ariaLabel">
         <svg class="ui-icon__svg" v-if="useSvg">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" :xlink:href="'#' + icon"></use>
         </svg>
@@ -24,6 +24,10 @@ export default {
             default: false
         },
         useSvg: {
+            type: Boolean,
+            default: false
+        },
+        mirror: {
             type: Boolean,
             default: false
         }
@@ -53,6 +57,10 @@ $ui-icon-size       : 1em !default;
         margin: 0;
         padding: 0;
         width: $ui-icon-size;
+    }
+
+    &.is-mirrored {
+        transform: scaleX(-1);
     }
 }
 </style>

--- a/src/UiMenuOption.vue
+++ b/src/UiMenuOption.vue
@@ -16,6 +16,7 @@
                     :icon="icon"
                     :remove-text="iconProps.removeText"
                     :use-svg="iconProps.useSvg"
+                    :mirror="iconProps.mirror"
 
                     v-if="icon"
                 ></ui-icon>


### PR DESCRIPTION
Adds a `mirror` prop to the `ui-icon`. Necessary for icons where a mirrored version does not exist and we cannot attach a class. Such as the sign in/out icon in the side-nav where we pass it in using an array of menu options. 
![mirror](https://user-images.githubusercontent.com/7193975/33346093-58a69b3c-d443-11e7-99da-039ce9d41516.gif)
